### PR TITLE
Fixes decode error in Indexer /accounts query

### DIFF
--- a/algonaut_model/src/indexer/v2/mod.rs
+++ b/algonaut_model/src/indexer/v2/mod.rs
@@ -722,7 +722,7 @@ pub struct ApplicationLocalState {
 
     /// `tkv` storage.
     #[serde(rename = "key-value")]
-    pub key_value: TealKeyValueStore,
+    pub key_value: Option<TealKeyValueStore>,
 
     /// Round when the account opted into the application.
     #[serde(rename = "opted-in-at-round")]


### PR DESCRIPTION
In my app, I have been attempting to query the /accounts endpoint with the indexer as follows:
```
            let query = QueryAccount {
                limit: Some(2),
                ..QueryAccount::default()
            };

            indexer.accounts(&query).await?;
```
The above call returns the following error:
```
Err(
    Request(
        RequestError {
            url: None,
            details: Client {
                description: "error decoding response body: missing field `key-value` at line 1 column 2399",
            },
        },
    ),
)
```

Testing the indexer api with curl, I believe that not every "apps-local-state" element is guaranteed to have a "key-value" set, so I think this should be an Option value, and this change does indeed fix the problem when testing locally.

I'm not very experienced with Rust, so let me know if I'm missing something. I appreciate your work on this great project!